### PR TITLE
emit event via cpi

### DIFF
--- a/programs/earn/Cargo.toml
+++ b/programs/earn/Cargo.toml
@@ -25,6 +25,7 @@ devnet = []
 anchor-lang = { workspace = true, features = [
     "anchor-debug",
     "init-if-needed",
+    "event-cpi"
 ] }
 anchor-spl.workspace = true
 spl-token-2022.workspace = true

--- a/programs/earn/src/instructions/earn_authority/claim_for.rs
+++ b/programs/earn/src/instructions/earn_authority/claim_for.rs
@@ -11,6 +11,7 @@ use crate::{
     utils::token::mint_tokens,
 };
 
+#[event_cpi]
 #[derive(Accounts)]
 pub struct ClaimFor<'info> {
     pub earn_authority: Signer<'info>,
@@ -124,7 +125,7 @@ pub fn handler(ctx: Context<ClaimFor>, snapshot_balance: u64) -> Result<()> {
         ctx.accounts.global_account.max_supply = ctx.accounts.mint.supply;
     }
 
-    emit!(RewardsClaim {
+    emit_cpi!(RewardsClaim {
         token_account: ctx.accounts.user_token_account.key(),
         recipient_token_account: ctx.accounts.user_token_account.key(),
         amount: rewards,

--- a/programs/ext_earn/Cargo.toml
+++ b/programs/ext_earn/Cargo.toml
@@ -19,7 +19,7 @@ mainnet = []
 devnet = []
 
 [dependencies]
-anchor-lang = { workspace = true, features = ["init-if-needed"] }
+anchor-lang = { workspace = true, features = ["init-if-needed", "event-cpi"] }
 anchor-spl.workspace = true
 spl-token-2022.workspace = true
 cfg-if.workspace = true

--- a/programs/ext_earn/src/instructions/earn_authority/claim_for.rs
+++ b/programs/ext_earn/src/instructions/earn_authority/claim_for.rs
@@ -16,6 +16,7 @@ use crate::{
     utils::token::mint_tokens,
 };
 
+#[event_cpi]
 #[derive(Accounts)]
 pub struct ClaimFor<'info> {
     pub earn_authority: Signer<'info>,
@@ -157,7 +158,7 @@ pub fn handler(ctx: Context<ClaimFor>, snapshot_balance: u64) -> Result<()> {
         &ctx.accounts.token_2022,         // token program
     )?;
 
-    emit!(RewardsClaim {
+    emit_cpi!(RewardsClaim {
         token_account: ctx.accounts.earner_account.user_token_account,
         recipient_token_account: ctx.accounts.user_token_account.key(),
         amount: rewards,


### PR DESCRIPTION
Logs get truncated after 10kb which means we would likely only be able to do 10 claims before these events are truncated. This data is used by the subgraph which is used by the SDK to get historical claims for a user.

considerations
- adding this CPI cost an extra ~4000 compute units (the claim ix currently consumes ~26800 units : +15%) 
- no increase in transaction size (the event authority will be added to a lookup table as it never changes)
- we could probably do more like 25 claims per transaction (rather than 10)
- we would not notice if a log was truncated and we would miss the event
- transaction fee would be 15% more expensive

putting this in draft for feedback
do we want to pay and extra 15% to not worry about truncated logs and to send 1/3 of the transactions for claims?