### PR TITLE
PROTO-100:  Set m mint instruction on ext_earn

### DIFF
--- a/programs/ext_earn/src/instructions/admin/mod.rs
+++ b/programs/ext_earn/src/instructions/admin/mod.rs
@@ -4,6 +4,7 @@ pub mod add_earn_manager;
 pub mod initialize;
 pub mod remove_earn_manager;
 pub mod set_earn_authority;
+pub mod set_m_mint;
 
 pub use add_earn_manager::AddEarnManager;
 pub(crate) use add_earn_manager::__client_accounts_add_earn_manager;
@@ -13,6 +14,8 @@ pub use remove_earn_manager::RemoveEarnManager;
 pub(crate) use remove_earn_manager::__client_accounts_remove_earn_manager;
 pub use set_earn_authority::SetEarnAuthority;
 pub(crate) use set_earn_authority::__client_accounts_set_earn_authority;
+pub use set_m_mint::SetMMint;
+pub(crate) use set_m_mint::__client_accounts_set_m_mint;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "cpi")] {
@@ -20,5 +23,6 @@ cfg_if::cfg_if! {
         pub(crate) use initialize::__cpi_client_accounts_initialize;
         pub(crate) use remove_earn_manager::__cpi_client_accounts_remove_earn_manager;
         pub(crate) use set_earn_authority::__cpi_client_accounts_set_earn_authority;
+        pub(crate) use set_m_mint::__cpi_client_accounts_set_m_mint;
     }
 }

--- a/programs/ext_earn/src/instructions/admin/set_m_mint.rs
+++ b/programs/ext_earn/src/instructions/admin/set_m_mint.rs
@@ -18,6 +18,7 @@ pub struct SetMMint<'info> {
         mut,
         seeds = [EXT_GLOBAL_SEED],
         has_one = admin @ ExtError::NotAuthorized,
+        has_one = m_mint @ ExtError::InvalidAccount,
         bump = global_account.bump,
     )]
     pub global_account: Account<'info, ExtGlobal>,
@@ -29,8 +30,18 @@ pub struct SetMMint<'info> {
     )]
     pub m_vault: AccountInfo<'info>,
 
+    pub m_mint: InterfaceAccount<'info, Mint>,
+
     #[account(
-        token::token_program = Token2022::id(),
+        associated_token::mint = global_account.m_mint,
+        associated_token::authority = m_vault,
+        associated_token::token_program = Token2022::id(),
+    )]
+    pub vault_m_token_account: InterfaceAccount<'info, TokenAccount>,
+
+    #[account(
+        mint::token_program = Token2022::id(),
+        mint::decimals = m_mint.decimals,
     )]
     pub new_m_mint: InterfaceAccount<'info, Mint>,
 
@@ -40,13 +51,6 @@ pub struct SetMMint<'info> {
         associated_token::token_program = Token2022::id(),
     )]
     pub new_vault_m_token_account: InterfaceAccount<'info, TokenAccount>,
-
-    #[account(
-        associated_token::mint = global_account.m_mint,
-        associated_token::authority = m_vault,
-        associated_token::token_program = Token2022::id(),
-    )]
-    pub vault_m_token_account: InterfaceAccount<'info, TokenAccount>,
 }
 
 pub fn handler(ctx: Context<SetMMint>) -> Result<()> {

--- a/programs/ext_earn/src/instructions/admin/set_m_mint.rs
+++ b/programs/ext_earn/src/instructions/admin/set_m_mint.rs
@@ -1,0 +1,35 @@
+// ext_earn/instructions/admin/set_m_mint.rs
+
+// external dependencies
+use anchor_lang::prelude::*;
+use anchor_spl::token_interface::{Mint, Token2022};
+
+// local dependencies
+use crate::{
+    errors::ExtError,
+    state::{ExtGlobal, EXT_GLOBAL_SEED},
+};
+
+#[derive(Accounts)]
+pub struct SetMMint<'info> {
+    pub admin: Signer<'info>,
+
+    #[account(
+        mut,
+        seeds = [EXT_GLOBAL_SEED],
+        has_one = admin @ ExtError::NotAuthorized,
+        bump = global_account.bump,
+    )]
+    pub global_account: Account<'info, ExtGlobal>,
+
+    #[account(
+        token::token_program = Token2022::id(),
+    )]
+    pub m_mint: InterfaceAccount<'info, Mint>,
+}
+
+pub fn handler(ctx: Context<SetMMint>) -> Result<()> {
+    ctx.accounts.global_account.m_mint = ctx.accounts.m_mint.key();
+
+    Ok(())
+}

--- a/programs/ext_earn/src/lib.rs
+++ b/programs/ext_earn/src/lib.rs
@@ -18,14 +18,8 @@ pub mod ext_earn {
 
     // Admin instructions
 
-    pub fn initialize(
-        ctx: Context<Initialize>,
-        earn_authority: Pubkey,
-    ) -> Result<()> {
-        instructions::admin::initialize::handler(
-            ctx,
-            earn_authority,
-        )
+    pub fn initialize(ctx: Context<Initialize>, earn_authority: Pubkey) -> Result<()> {
+        instructions::admin::initialize::handler(ctx, earn_authority)
     }
 
     pub fn set_earn_authority(
@@ -33,6 +27,10 @@ pub mod ext_earn {
         new_earn_authority: Pubkey,
     ) -> Result<()> {
         instructions::admin::set_earn_authority::handler(ctx, new_earn_authority)
+    }
+
+    pub fn set_m_mint(ctx: Context<SetMMint>) -> Result<()> {
+        instructions::admin::set_m_mint::handler(ctx)
     }
 
     pub fn add_earn_manager(
@@ -59,10 +57,7 @@ pub mod ext_earn {
 
     // Earn manager instructions
 
-    pub fn add_earner(
-        ctx: Context<AddEarner>,
-        user: Pubkey,
-    ) -> Result<()> {
+    pub fn add_earner(ctx: Context<AddEarner>, user: Pubkey) -> Result<()> {
         instructions::earn_manager::add_earner::handler(ctx, user)
     }
 
@@ -72,7 +67,7 @@ pub mod ext_earn {
 
     pub fn configure_earn_manager(
         ctx: Context<ConfigureEarnManager>,
-        fee_bps: Option<u64>
+        fee_bps: Option<u64>,
     ) -> Result<()> {
         instructions::earn_manager::configure::handler(ctx, fee_bps)
     }
@@ -96,7 +91,7 @@ pub mod ext_earn {
     pub fn unwrap(ctx: Context<Unwrap>, amount: u64) -> Result<()> {
         instructions::open::unwrap::handler(ctx, amount)
     }
-    
+
     pub fn remove_orphaned_earner(ctx: Context<RemoveOrphanedEarner>) -> Result<()> {
         instructions::open::remove_orphaned_earner::handler(ctx)
     }


### PR DESCRIPTION
This PR adds a `set_m_mint` instruction that the admin can call to update the M token mint. The idea is to make upgrading to a different M mint possible in the future. This can be added later on via a program upgrade if we don't want to include it initially.