### PR TITLE
Ottersec: PROTO-119: use latest ts when creating earner

### DIFF
--- a/programs/earn/src/instructions/open/add_registrar_earner.rs
+++ b/programs/earn/src/instructions/open/add_registrar_earner.rs
@@ -65,7 +65,7 @@ pub fn handler(
 
     ctx.accounts.earner_account.set_inner(Earner {
         last_claim_index: ctx.accounts.global_account.index,
-        last_claim_timestamp: Clock::get()?.unix_timestamp.try_into().unwrap(),
+        last_claim_timestamp: ctx.accounts.global_account.timestamp,
         bump: ctx.bumps.earner_account,
         user,
         user_token_account: ctx.accounts.user_token_account.key(),

--- a/programs/ext_earn/src/instructions/earn_manager/add_earner.rs
+++ b/programs/ext_earn/src/instructions/earn_manager/add_earner.rs
@@ -50,16 +50,12 @@ pub struct AddEarner<'info> {
     pub system_program: Program<'info, System>,
 }
 
-pub fn handler(
-    ctx: Context<AddEarner>,
-    user: Pubkey,
-) -> Result<()> {
-
+pub fn handler(ctx: Context<AddEarner>, user: Pubkey) -> Result<()> {
     ctx.accounts.earner_account.set_inner(Earner {
         earn_manager: ctx.accounts.signer.key(),
         recipient_token_account: None,
         last_claim_index: ctx.accounts.global_account.index,
-        last_claim_timestamp: Clock::get()?.unix_timestamp.try_into().unwrap(),
+        last_claim_timestamp: ctx.accounts.global_account.timestamp,
         bump: ctx.bumps.earner_account,
         user,
         user_token_account: ctx.accounts.user_token_account.key(),


### PR DESCRIPTION
when calculating a user's time-weighted balance we use `last_claim_timestamp` -> `global.timestamp`

when creating an earner we used `Clock::get()?.unix_timestamp` so that they only start earning when they are created and not since the last index update

however, snapshot_balance should be for the entire period otherwise the rewards will be incorrect

ex. earner acquires 1000 tokens 30s before a claim cycle, SDK uses `last_claim_timestamp` (which is 30s ago) and `global.timestamp` to get a time-weighted balance of 1000. User then earns yield on all those token for the whole period (instead of just 30s)

using `global.timestamp` instead of `Clock::get()?.unix_timestamp` means `snapshot_balance` will reflect the balance for the whole period. (side effect is they earn yield on tokens they were holding before becoming and earner)

alternatively, the SDK could be aware of this situations and adjust the calcs accordingly 