### PR TITLE
trivial - update sync IndexUpdate event name

### DIFF
--- a/programs/ext_earn/src/instructions/earn_authority/sync.rs
+++ b/programs/ext_earn/src/instructions/earn_authority/sync.rs
@@ -6,9 +6,7 @@ use crate::{
     errors::ExtError,
     state::{ExtGlobal, EXT_GLOBAL_SEED},
 };
-use earn::{
-    state::{Global as EarnGlobal},
-};
+use earn::state::Global as EarnGlobal;
 
 #[derive(Accounts)]
 pub struct Sync<'info> {
@@ -31,7 +29,7 @@ pub fn handler(ctx: Context<Sync>) -> Result<()> {
     ctx.accounts.global_account.index = ctx.accounts.m_earn_global_account.index;
     ctx.accounts.global_account.timestamp = ctx.accounts.m_earn_global_account.timestamp;
 
-    emit!(IndexUpdate {
+    emit!(SyncIndexUpdate {
         index: ctx.accounts.global_account.index,
         ts: ctx.accounts.global_account.timestamp,
     });
@@ -40,7 +38,7 @@ pub fn handler(ctx: Context<Sync>) -> Result<()> {
 }
 
 #[event]
-pub struct IndexUpdate {
+pub struct SyncIndexUpdate {
     pub index: u64,
     pub ts: u64,
 }


### PR DESCRIPTION
event discriminators on events are only based on their name so this would be easily mixed with the index update event on the earn program

you can technically use previous logs to see which program produced the log and the data will likely be the same between the events but easier to reason about them when they are distinct events