### PR TITLE
PROTO-245: AR-15: Token constraints should be consistent with `m_ext`

### DIFF
--- a/programs/ext_earn/src/instructions/open/unwrap.rs
+++ b/programs/ext_earn/src/instructions/open/unwrap.rs
@@ -51,6 +51,7 @@ pub struct Unwrap<'info> {
     #[account(
         mut,
         token::mint = m_mint,
+        token::token_program = m_token_program,
     )]
     pub to_m_token_account: InterfaceAccount<'info, TokenAccount>,
 
@@ -58,14 +59,14 @@ pub struct Unwrap<'info> {
         mut,
         associated_token::mint = m_mint,
         associated_token::authority = m_vault,
-        associated_token::token_program = token_2022,
+        associated_token::token_program = m_token_program,
     )]
     pub vault_m_token_account: InterfaceAccount<'info, TokenAccount>,
 
     #[account(
         mut,
         token::mint = ext_mint,
-        token::authority = token_authority,
+        token::token_program = token_2022,
     )]
     pub from_ext_token_account: InterfaceAccount<'info, TokenAccount>,
 

--- a/programs/ext_earn/src/instructions/open/wrap.rs
+++ b/programs/ext_earn/src/instructions/open/wrap.rs
@@ -59,13 +59,14 @@ pub struct Wrap<'info> {
         mut,
         associated_token::mint = m_mint,
         associated_token::authority = m_vault,
-        associated_token::token_program = token_2022,
+        associated_token::token_program = m_token_program,
     )]
     pub vault_m_token_account: InterfaceAccount<'info, TokenAccount>,
 
     #[account(
         mut,
         token::mint = ext_mint,
+        token::token_program = token_2022,
     )]
     pub to_ext_token_account: InterfaceAccount<'info, TokenAccount>,
 

--- a/tests/unit/ext_earn.test.ts
+++ b/tests/unit/ext_earn.test.ts
@@ -3478,7 +3478,7 @@ describe('ExtEarn unit tests', () => {
         await prepWrap(earnerOne, wrongATA);
 
         // Attempt to send the transaction
-        // Expect revert with TokenOwner error
+        // Expect revert on the token program due to permissions
         await expectSystemError(
           extEarn.methods
             .wrap(mintAmount)
@@ -3724,7 +3724,7 @@ describe('ExtEarn unit tests', () => {
       });
 
       // given the signer is not the authority on the user M token account
-      // it reverts with a ConstraintTokenOwner error
+      // it reverts with an error on the token program
       test('Signer is not the authority on the from Ext token account - reverts', async () => {
         // Get the ATA for another user
         const mATA = await getATA(mMint.publicKey, earnerOne.publicKey);
@@ -3734,14 +3734,13 @@ describe('ExtEarn unit tests', () => {
         await prepUnwrap(earnerOne, mATA, wrongExtATA);
 
         // Attempt to send the transaction
-        // Expect revert with TokenOwner error
-        await expectAnchorError(
+        // Expect revert in token program due to permissions error
+        await expectSystemError(
           extEarn.methods
             .unwrap(wrappedAmount)
             .accountsPartial({ ...accounts })
             .signers([earnerOne])
             .rpc(),
-          'ConstraintTokenOwner',
         );
       });
 


### PR DESCRIPTION
In addition to fixing the token program constraints on the token accounts, I also removed the authority constraint on the `from_ext_token_account` to allow for delegated addresses to unwrap. This is consistent with `m_ext` and `ext_swap`.