### PR TITLE
do not merge: compatibility with existing earn program

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ define upgrade_program
 		--keypair $(DEVNET_KEYPAIR) \
 		--max-sign-attempts $(MAX_SIGN_ATTEMPTS) \
 		--buffer temp-buffer.json \
-		target/deploy/$(1).so 
+		target/verifiable/$(1).so 
 	@echo "Upgrading program with buffer $$(solana address --keypair temp-buffer.json)" 
 	@solana program upgrade \
 		--keypair $(DEVNET_KEYPAIR) \

--- a/programs/earn/src/lib.rs
+++ b/programs/earn/src/lib.rs
@@ -25,7 +25,7 @@ solana_security_txt::security_txt! {
     auditors: "Asymmetric Research, Sec3, OtterSec, Halborn"
 }
 
-declare_id!("mz2vDzjbQDUDXBH6FPF5s4odCJ4y8YLE5QWaZ8XdZ9Z");
+declare_id!("MzeRokYa9o1ZikH6XHRiSS5nD8mNjZyHpLCBRTBSY4c");
 
 #[program]
 pub mod earn {

--- a/programs/portal/src/instructions/release_inbound.rs
+++ b/programs/portal/src/instructions/release_inbound.rs
@@ -1,10 +1,7 @@
 use anchor_lang::prelude::*;
 use anchor_spl::{associated_token::get_associated_token_address_with_program_id, token_interface};
 use earn::{
-    cpi::accounts::PropagateIndex,
-    program::Earn,
-    state::{EarnGlobal, GLOBAL_SEED},
-    utils::conversion::amount_to_principal_down,
+    cpi::accounts::PropagateIndex, program::Earn, utils::conversion::amount_to_principal_down,
 };
 use spl_token_2022::onchain;
 
@@ -57,12 +54,8 @@ pub struct ReleaseInboundMint<'info> {
 
     pub earn_program: Program<'info, Earn>,
 
-    #[account(
-        seeds = [GLOBAL_SEED],
-        seeds::program = earn::ID,
-        bump = m_global.bump,
-    )]
-    pub m_global: Box<Account<'info, EarnGlobal>>,
+    /// CHECK: checked by earn program
+    pub m_global: UncheckedAccount<'info>,
 }
 
 #[derive(AnchorDeserialize, AnchorSerialize)]

--- a/programs/portal/src/instructions/transfer_extension.rs
+++ b/programs/portal/src/instructions/transfer_extension.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_spl::token_interface::{approve, Approve, Mint, TokenAccount, TokenInterface};
-use earn::state::{EarnGlobal, GLOBAL_SEED};
+use earn::state::GLOBAL_SEED;
 use ext_swap::{accounts::SwapGlobal, program::ExtSwap};
 
 use crate::{
@@ -22,13 +22,6 @@ pub struct TransferExtensionBurn<'info> {
         bump = swap_global.bump,
     )]
     pub swap_global: Box<Account<'info, SwapGlobal>>,
-
-    #[account(
-        seeds = [GLOBAL_SEED],
-        seeds::program = earn::ID,
-        bump = m_global.bump,
-    )]
-    pub m_global: Box<Account<'info, EarnGlobal>>,
 
     #[account(
         mut,


### PR DESCRIPTION
the current earn program has a different program id
also, Global was renamed to EarnGlobal so the account discriminator does not match

opening this PR just to track the changes to support the portal upgrade before earn is upgraded