### PR TITLE
imp(cli): avoid failing yield distribution altogether on stale db and improve Slack bot output

### DIFF
--- a/sdk/src/earn_auth.ts
+++ b/sdk/src/earn_auth.ts
@@ -223,6 +223,11 @@ export class EarnAuthority {
           })
           .instruction();
       case 'ScaledUi':
+        // The `ScaledUi` variant's `sync` method takes a different set of accounts than the `Crank` variant.
+        //
+        // `this.program` is built from the `Crank` variant IDL above, so `.methods.sync()` would resolve
+        // the wrong accounts here — we hand-build the raw TransactionInstruction instead. The account order
+        // below must match the on-chain ScaledUi `sync` signature.
         const vault = PublicKey.findProgramAddressSync([Buffer.from('m_vault')], this.program.programId)[0];
         return {
           keys: [
@@ -263,6 +268,9 @@ export class EarnAuthority {
             },
           ],
           programId: this.program.programId,
+          // Anchor instruction discriminator for `sync`: sha256("global:sync")[0..8].
+          // `sync` takes no args, so the discriminator is the entire instruction data.
+          // Kept in sync with `instructions[].discriminator` for "sync" in ./idl/m_ext.json.
           data: Buffer.from([4, 219, 40, 164, 21, 157, 189, 88]),
         };
       default:

--- a/services/shared/balances.ts
+++ b/services/shared/balances.ts
@@ -50,5 +50,5 @@ export async function checkBlockchainBalance(blockchain: BlockchainType, rpc: st
   const data = await resp.json();
   const balance = config.parseBalance(data.result);
 
-  return {amount: balance, belowTreshold: balance > config.defaultWarnThreshold};
+  return {amount: balance, belowTreshold: balance < config.defaultWarnThreshold};
 }

--- a/services/shared/balances.ts
+++ b/services/shared/balances.ts
@@ -21,7 +21,7 @@ const blockchainConfigs = {
 // gas token is below the expected threshold.
 type BotBalance = {
   amount: bigint,
-  belowTreshold: boolean
+  belowThreshold: boolean
 }
 
 // Checks the configured bot account's balance of the provided network's native gas token.
@@ -50,5 +50,5 @@ export async function checkBlockchainBalance(blockchain: BlockchainType, rpc: st
   const data = await resp.json();
   const balance = config.parseBalance(data.result);
 
-  return {amount: balance, belowTreshold: balance < config.defaultWarnThreshold};
+  return {amount: balance, belowThreshold: balance < config.defaultWarnThreshold};
 }

--- a/services/shared/balances.ts
+++ b/services/shared/balances.ts
@@ -1,5 +1,3 @@
-import { Logger } from '@m0-foundation/solana-m-sdk';
-
 type BlockchainType = 'solana' | 'ethereum';
 
 const blockchainConfigs = {
@@ -19,42 +17,38 @@ const blockchainConfigs = {
   },
 };
 
-export async function logBlockchainBalance(blockchain: BlockchainType, rpc: string, address: string, logger: Logger) {
-  try {
-    const config = blockchainConfigs[blockchain];
+// A helper type to indicate whether the bot's amount of the network's native
+// gas token is below the expected threshold.
+type BotBalance = {
+  amount: bigint,
+  belowTreshold: boolean
+}
 
-    const raw = JSON.stringify({
-      method: config.method,
-      params: config.getParams(address),
-      id: 1,
-      jsonrpc: '2.0',
-    });
+// Checks the configured bot account's balance of the provided network's native gas token.
+// Returns the balance amount and whether it's below the expected threshold.
+export async function checkBlockchainBalance(blockchain: BlockchainType, rpc: string, address: string): Promise<BotBalance> {
+  const config = blockchainConfigs[blockchain];
 
-    const requestOptions = {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: raw,
-    };
+  const raw = JSON.stringify({
+    method: config.method,
+    params: config.getParams(address),
+    id: 1,
+    jsonrpc: '2.0',
+  });
 
-    const resp = await fetch(rpc, requestOptions);
-    if (!resp.ok) {
-      logger.error(`Failed to fetch ${blockchain} balance`, {
-        status: resp.status,
-        statusText: resp.statusText,
-      });
-      return;
-    }
+  const requestOptions = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: raw,
+  };
 
-    const data = await resp.json();
-    const balance = config.parseBalance(data.result);
-
-    const log = balance > config.defaultWarnThreshold ? logger.info : logger.error;
-    log(`${blockchain} wallet balance`, {
-      balance: balance.toString(),
-      balanceDecimal: Number(balance) / config.decimalDivisor,
-      address,
-    });
-  } catch (error) {
-    logger.error(new Error(`Error fetching ${blockchain} balance: ${error}`));
+  const resp = await fetch(rpc, requestOptions);
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch ${blockchain} balance; status: ${resp.status} - ${resp.statusText}`);
   }
+
+  const data = await resp.json();
+  const balance = config.parseBalance(data.result);
+
+  return {amount: balance, belowTreshold: balance > config.defaultWarnThreshold};
 }

--- a/services/shared/slack.ts
+++ b/services/shared/slack.ts
@@ -1,7 +1,6 @@
 export interface SlackMessage {
   messages: string[];
   service: 'yield-bot'; // extend in case a new service is added going forward.
-  level: string;
   devnet?: boolean;
   explorer?: string;
 }
@@ -13,12 +12,12 @@ export async function sendSlackMessage(message: SlackMessage) {
     return;
   }
 
-  const { messages, level, service } = message;
+  const { messages, service } = message;
 
   const body = {
     service,
-    level,
-    message: '• ' + messages.join('\n• ') + '\n',
+    // Each caller supplies fully-formatted entries; separate them with a blank line.
+    message: messages.join('\n\n'),
   };
 
   const response = await fetch(webhookUrl, {

--- a/services/yield-bot/main.ts
+++ b/services/yield-bot/main.ts
@@ -30,10 +30,11 @@ if (process.env.LOKI_URL) {
 const limiter = new RateLimiter({ tokensPerInterval: 2, interval: 1000 });
 
 // meta info from job will be posted to slack
+//
+// NOTE: This format is defined by the actual Slack workflow for the "Solana Bot".
 let slackMessage: SlackMessage = {
   messages: [],
   service: 'yield-bot',
-  level: 'info',
 };
 
 export interface ParsedOptions extends EnvOptions {
@@ -43,9 +44,29 @@ export interface ParsedOptions extends EnvOptions {
   tip: number;
 }
 
-// extensions
-const wM = new PublicKey('wMXX1K1nca5W4pZr1piETe78gcAVVrEFi9f4g46uXko');
-const USDKY = new PublicKey('extMahs9bUFMYcviKCvnSRaXgs5PcqmMzcnHRtTqE85');
+// One structured Slack entry per extension we distribute yield to. `programId` is retained for
+// logging/metadata even though the Slack output shows the friendly `name` instead of the raw ID.
+type YieldToExtensionLog = {
+  name: string;
+  programId: string;
+  success: boolean;
+  text: string;
+};
+
+// Data returned by a successful `distributeYield` run, used to build the Slack success text.
+type DistributeResult = {
+  signature: string;
+  distribution?: { amountUsd: number; earners: number }; // only for the Crank variant with earners
+};
+
+// extensions we distribute yield to, keyed by a human-friendly display name
+const EXTENSIONS: { name: string; programId: PublicKey }[] = [
+  { name: 'wM', programId: new PublicKey('wMXX1K1nca5W4pZr1piETe78gcAVVrEFi9f4g46uXko') },
+  { name: 'USDKy', programId: new PublicKey('extMahs9bUFMYcviKCvnSRaXgs5PcqmMzcnHRtTqE85') },
+];
+
+// structured per-extension results; rendered into the Slack summary in the finally flush below
+const yieldLogs: YieldToExtensionLog[] = [];
 
 // entrypoint for the yield bot command
 export async function yieldCLI() {
@@ -60,21 +81,23 @@ export async function yieldCLI() {
         env = getEnv();
 
         // Check the bot's balance ahead of the sync transactions.
-        const botBalance = await checkBlockchainBalance('solana', env.connection.rpcEndpoint, env.signerPubkey.toBase58());
+        const botBalance = await checkBlockchainBalance(
+          'solana',
+          env.connection.rpcEndpoint,
+          env.signerPubkey.toBase58(),
+        );
         if (botBalance.belowTreshold) {
           const msg = `Bot balance is below configured threshold: ${botBalance.amount}. Top up the balance at the next possible occasion.`;
           logger.warn(msg);
           // NOTE: we're sending a separate Slack message here for visibility of the bot balance being low.
           sendSlackMessage({
-            service: "yield-bot",
-            level: "warn",
-            messages: [msg],
-          })
+            service: 'yield-bot',
+            messages: [":warning: " + msg],
+          });
         }
       } catch (error: any) {
         logger.error(error);
-        slackMessage.level = 'error';
-        slackMessage.messages.push(`${error}`);
+        yieldLogs.push({ name: 'startup', programId: '-', success: false, text: `${error}` });
 
         return;
       }
@@ -87,19 +110,23 @@ export async function yieldCLI() {
         tip: Number.parseInt(tip, 10),
       };
 
-      // distribute yield for each program
-      for (const pid of [wM, USDKY]) {
-        logger.addMetaField('programId', pid.toBase58());
-        slackMessage.messages.push(`Distributing yield for program ${pid.toBase58()}`);
+      // distribute yield for each extension, recording a structured result per program
+      for (const { name, programId } of EXTENSIONS) {
+        logger.addMetaField('programId', programId.toBase58());
 
         try {
           // NOTE: this might throw on a Crank variant program if the database is not in sync.
-          // In that case, this sends an error log + Slack message and continue.
-          await distributeYield(options, pid);
+          // In that case, we record a failed log entry and continue with the next extension.
+          const result = await distributeYield(options, programId);
+          yieldLogs.push({
+            name,
+            programId: programId.toBase58(),
+            success: true,
+            text: buildSuccessText(options, result),
+          });
         } catch (error: any) {
           logger.error(error);
-          slackMessage.level = 'error';
-          slackMessage.messages.push(`${error}`);
+          yieldLogs.push({ name, programId: programId.toBase58(), success: false, text: `${error}` });
         }
       }
     });
@@ -107,13 +134,13 @@ export async function yieldCLI() {
   await program.parseAsync(process.argv);
 }
 
-async function distributeYield(opt: ParsedOptions, programID: PublicKey): Promise<void> {
+async function distributeYield(opt: ParsedOptions, programID: PublicKey): Promise<DistributeResult> {
   const auth = await EarnAuthority.load(opt.connection, programID, logger);
   const ixs: TransactionInstruction[] = [];
+  let distribution: DistributeResult['distribution'];
 
   // sync index if applicable (will throw an error for `no-yield` as that doesn't have a sync method)
   ixs.push(await auth.buildIndexSyncInstruction());
-  slackMessage.messages.push('Syncing index');
 
   if (auth.global.variant === 'Crank') {
     // The Crank variant requires access to an indexing database in order to recursively
@@ -138,7 +165,7 @@ async function distributeYield(opt: ParsedOptions, programID: PublicKey): Promis
       const distributed = await auth.simulateAndValidateClaimIxs(ixs);
 
       const amountDec = distributed.toNumber() / 1e6;
-      slackMessage.messages.push(`Distributed ${distributed} ($${amountDec.toFixed(0)}) to ${claimIxs} earners`);
+      distribution = { amountUsd: amountDec, earners: claimIxs };
 
       logger.info('distributing yield', {
         amount: distributed.toNumber(),
@@ -149,9 +176,38 @@ async function distributeYield(opt: ParsedOptions, programID: PublicKey): Promis
 
   // send transaction
   const signature = await buildAndSendTransaction(opt, ixs);
-  slackMessage.messages.push(`Yield updates complete: ${signature[0]}\n`);
 
-  return;
+  return { signature: signature[0], distribution };
+}
+
+// Builds a bare Solana explorer link for a transaction. A bare URL is used (rather than mrkdwn
+// `<url|text>`) so it stays clickable regardless of how the Slack workflow renders the variable.
+function explorerTxUrl(signature: string, isDevnet: boolean): string {
+  const base = `https://explorer.solana.com/tx/${signature}`;
+  return isDevnet ? `${base}?cluster=devnet` : base;
+}
+
+// Composes the body shown under a successful extension: the distributed amount (Crank only) followed
+// by an explorer link, or a dry-run notice when no transaction was actually sent.
+function buildSuccessText(opt: ParsedOptions, result: DistributeResult): string {
+  const lines: string[] = [];
+
+  if (result.distribution) {
+    lines.push(`Distributed $${result.distribution.amountUsd.toFixed(0)} to ${result.distribution.earners} earners`);
+  }
+
+  lines.push(
+    opt.dryRun ? 'Dry run — transaction built & simulated, not sent.' : explorerTxUrl(result.signature, opt.isDevnet),
+  );
+
+  return lines.join('\n');
+}
+
+// Renders a single structured log into the mrkdwn block posted to Slack: a status emoji + bold name
+// header, followed by the extension's detail text on the next line(s).
+function renderYieldLog(log: YieldToExtensionLog): string {
+  const status = log.success ? ':white_check_mark:' : ':x:';
+  return `${status} *${log.name}*\n${log.text}`;
 }
 
 async function buildAndSendTransaction(
@@ -343,9 +399,9 @@ function getLokiTransport(host: string, logger: winston.Logger) {
 // do not run the cli if this is being imported by jest
 if (!process.argv[1].endsWith('jest.js')) {
   yieldCLI().finally(async () => {
-    if (slackMessage?.messages.length === 0) {
-      slackMessage?.messages.push('No actions taken');
-    }
+    // Render each structured log into the Slack summary.
+    slackMessage.messages = yieldLogs.length ? yieldLogs.map(renderYieldLog) : ['No actions taken'];
+
     await lokiTransport?.flush();
     await sendSlackMessage(slackMessage);
     process.exit(0);

--- a/services/yield-bot/main.ts
+++ b/services/yield-bot/main.ts
@@ -11,7 +11,7 @@ import * as multisig from '@sqds/multisig';
 import { instructions } from '@sqds/multisig';
 import { RateLimiter } from 'limiter';
 import { sendSlackMessage, SlackMessage } from 'shared/slack';
-import { logBlockchainBalance } from 'shared/balances';
+import { checkBlockchainBalance } from 'shared/balances';
 import LokiTransport from 'winston-loki';
 import winston from 'winston';
 import { validateDatabaseData } from 'shared/validation';
@@ -55,52 +55,73 @@ export async function yieldCLI() {
     .command('distribute')
     .option('-d, --dryRun [bool]', 'Build and simulate transactions without sending them', false)
     .action(async ({ dryRun, bundle, tip }) => {
+      let env: EnvOptions;
       try {
-        const env = getEnv();
+        env = getEnv();
 
-        await logBlockchainBalance('solana', env.connection.rpcEndpoint, env.signerPubkey.toBase58(), logger);
-
-        const options: ParsedOptions = {
-          ...env,
-          builder: new TransactionBuilder(env.connection, logger),
-          dryRun,
-          bundle,
-          tip: Number.parseInt(tip, 10),
-        };
-
-        await validation(options);
-
-        // distribute yield for each program
-        for (const pid of [wM, USDKY]) {
-          logger.addMetaField('programId', pid.toBase58());
-          slackMessage.messages.push(`Distributing yield for program ${pid.toBase58()}`);
-
-          await distributeYield(options, pid);
+        // Check the bot's balance ahead of the sync transactions.
+        const botBalance = await checkBlockchainBalance('solana', env.connection.rpcEndpoint, env.signerPubkey.toBase58());
+        if (botBalance.belowTreshold) {
+          const msg = `Bot balance is below configured threshold: ${botBalance.amount}. Top up the balance at the next possible occasion.`;
+          logger.warn(msg);
+          // NOTE: we're sending a separate Slack message here for visibility of the bot balance being low.
+          sendSlackMessage({
+            service: "yield-bot",
+            level: "warn",
+            messages: [msg],
+          })
         }
       } catch (error: any) {
         logger.error(error);
         slackMessage.level = 'error';
         slackMessage.messages.push(`${error}`);
+
+        return;
+      }
+
+      const options: ParsedOptions = {
+        ...env,
+        builder: new TransactionBuilder(env.connection, logger),
+        dryRun,
+        bundle,
+        tip: Number.parseInt(tip, 10),
+      };
+
+      // distribute yield for each program
+      for (const pid of [wM, USDKY]) {
+        logger.addMetaField('programId', pid.toBase58());
+        slackMessage.messages.push(`Distributing yield for program ${pid.toBase58()}`);
+
+        try {
+          // NOTE: this might throw on a Crank variant program if the database is not in sync.
+          // In that case, this sends an error log + Slack message and continue.
+          await distributeYield(options, pid);
+        } catch (error: any) {
+          logger.error(error);
+          slackMessage.level = 'error';
+          slackMessage.messages.push(`${error}`);
+        }
       }
     });
 
   await program.parseAsync(process.argv);
 }
 
-async function validation(opt: ParsedOptions) {
-  const auth = await EarnAuthority.load(opt.connection, wM, logger);
-  await validateDatabaseData(auth);
-}
-
 async function distributeYield(opt: ParsedOptions, programID: PublicKey): Promise<void> {
   const auth = await EarnAuthority.load(opt.connection, programID, logger);
   const ixs: TransactionInstruction[] = [];
 
-  // sync index if applicable
+  // sync index if applicable (will throw an error for `no-yield` as that doesn't have a sync method)
   ixs.push(await auth.buildIndexSyncInstruction());
   slackMessage.messages.push('Syncing index');
 
   if (auth.global.variant === 'Crank') {
+    // The Crank variant requires access to an indexing database in order to recursively
+    // calculate the required yield to pay out.
+    //
+    // This only relates to the Crank model because the scaled-ui variant just requires an index sync.
+    await validateDatabaseData(auth);
+
     // build claim instructions if there are any earners
     for (const earner of await auth.getAllEarners()) {
       // throttle requests

--- a/services/yield-bot/main.ts
+++ b/services/yield-bot/main.ts
@@ -29,7 +29,7 @@ if (process.env.LOKI_URL) {
 // rate limit claims
 const limiter = new RateLimiter({ tokensPerInterval: 2, interval: 1000 });
 
-// meta info from job will be posted to slack
+// This global var collects the information sent to Slack eventually.
 //
 // NOTE: This format is defined by the actual Slack workflow for the "Solana Bot".
 let slackMessage: SlackMessage = {
@@ -89,11 +89,7 @@ export async function yieldCLI() {
         if (botBalance.belowTreshold) {
           const msg = `Bot balance is below configured threshold: ${botBalance.amount}. Top up the balance at the next possible occasion.`;
           logger.warn(msg);
-          // NOTE: we're sending a separate Slack message here for visibility of the bot balance being low.
-          sendSlackMessage({
-            service: 'yield-bot',
-            messages: [":warning: " + msg],
-          });
+          slackMessage.messages.push(":warning: " + msg);
         }
       } catch (error: any) {
         logger.error(error);
@@ -207,7 +203,7 @@ function buildSuccessText(opt: ParsedOptions, result: DistributeResult): string 
 // header, followed by the extension's detail text on the next line(s).
 function renderYieldLog(log: YieldToExtensionLog): string {
   const status = log.success ? ':white_check_mark:' : ':x:';
-  return `${status} *${log.name}*\n${log.text}`;
+  return `${status} ${log.name} (${log.programId.toString()})\n${log.text}\n`;
 }
 
 async function buildAndSendTransaction(
@@ -400,7 +396,9 @@ function getLokiTransport(host: string, logger: winston.Logger) {
 if (!process.argv[1].endsWith('jest.js')) {
   yieldCLI().finally(async () => {
     // Render each structured log into the Slack summary.
-    slackMessage.messages = yieldLogs.length ? yieldLogs.map(renderYieldLog) : ['No actions taken'];
+    yieldLogs.map(renderYieldLog).forEach((entry) => {
+      slackMessage.messages.push(entry);
+    });
 
     await lokiTransport?.flush();
     await sendSlackMessage(slackMessage);

--- a/services/yield-bot/main.ts
+++ b/services/yield-bot/main.ts
@@ -86,7 +86,7 @@ export async function yieldCLI() {
           env.connection.rpcEndpoint,
           env.signerPubkey.toBase58(),
         );
-        if (botBalance.belowTreshold) {
+        if (botBalance.belowThreshold) {
           const msg = `Bot balance is below configured threshold: ${botBalance.amount}. Top up the balance at the next possible occasion.`;
           logger.warn(msg);
           slackMessage.messages.push(":warning: " + msg);

--- a/tests/unit/yieldbot.test.ts
+++ b/tests/unit/yieldbot.test.ts
@@ -31,6 +31,7 @@ describe('Yield bot tests', () => {
  * Mocks the request data for the yield bot
  */
 function mockRequestData(earner: PublicKey) {
+  // limit requests only to the mocked selection; disable any real outgoing network requests.
   nock.disableNetConnect();
 
   nock(API_URL)


### PR DESCRIPTION
This PR adjusts the main logic of the `services/yield-bot` implementation to avoid failing the job altogether if the indexed data in the MongoDB implementation (fed by the Substreams data) is stale.

This data is only required to distribute yield to the `crank` variant, which is only deployed for wrapped M.
For `scaled-ui` extensions updating the M index works regardless of the database.

Additionally, the generated output sent to Slack has been improved.

