### PR TITLE
chore: update org name

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,8 +7,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Solana $M: a Token-2022 mint whose yield accrues via the ScaledUiAmount multiplier. The `earn`
 program — the only program in this repo — receives the $M index + earner merkle root from
 Ethereum through the Portal and updates the mint multiplier. The Portal program lives in
-[solana-portal](https://github.com/m0-foundation/solana-portal); $M extensions (wM, `ext_swap`)
-live in [solana-m-extensions](https://github.com/m0-foundation/solana-m-extensions).
+[solana-portal](https://github.com/m0-platform/solana-portal); $M extensions (wM, `ext_swap`)
+live in [solana-m-extensions](https://github.com/m0-platform/solana-m-extensions).
 
 ## Build & Test Commands
 

--- a/Makefile
+++ b/Makefile
@@ -120,9 +120,9 @@ upgrade-earn-mainnet:
 #
 define deploy-yield-bot
 	railway environment $(1)
-	docker build --build-arg now="$$(date -u +"%Y-%m-%dT%H:%M:%SZ")" --platform linux/amd64 -t ghcr.io/m0-foundation/solana-m:yield-bot -f services/yield-bot/Dockerfile .
-	docker push ghcr.io/m0-foundation/solana-m:yield-bot
-	railway redeploy --service "yield bot" --yes
+	docker build --build-arg now="$$(date -u +"%Y-%m-%dT%H:%M:%SZ")" --platform linux/amd64 -t ghcr.io/m0-platform/solana-m:yield-bot -f services/yield-bot/Dockerfile .
+	docker push ghcr.io/m0-platform/solana-m:yield-bot
+	railway redeploy --service "yield bot - wM" --yes
 endef
 
 deploy-yield-bot-devnet:
@@ -149,8 +149,8 @@ endef
 define deploy-substream-mongo
 	$(call build-substream,$(1),$(3),sf.substreams.sink.database.v1.DatabaseChanges,map_transfer_events_to_db)
 	cp -f substreams/graph/m-token-transactions-v0.1.0.spkg substreams/db/m-token-transactions.spkg
-	docker build --platform linux/amd64 -t ghcr.io/m0-foundation/solana-m:substream-mongo-$(2) -f substreams/db/Dockerfile .
-	docker push ghcr.io/m0-foundation/solana-m:substream-mongo-$(2)
+	docker build --platform linux/amd64 -t ghcr.io/m0-platform/solana-m:substream-mongo-$(2) -f substreams/db/Dockerfile .
+	docker push ghcr.io/m0-platform/solana-m:substream-mongo-$(2)
 	railway redeploy --service substream-mongo --yes
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ define deploy-yield-bot
 	railway environment $(1)
 	docker build --build-arg now="$$(date -u +"%Y-%m-%dT%H:%M:%SZ")" --platform linux/amd64 -t ghcr.io/m0-platform/solana-m:yield-bot -f services/yield-bot/Dockerfile .
 	docker push ghcr.io/m0-platform/solana-m:yield-bot
-	railway redeploy --service "yield bot - wM" --yes
+	railway redeploy --service "yield bot" --yes
 endef
 
 deploy-yield-bot-devnet:

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ other governance-approved actors) are thawed.
 | [`audits/`](audits/) | Audit reports |
 
 Related repos: the Portal program lives in
-[`solana-portal`](https://github.com/m0-foundation/solana-portal); $M extensions (wM and
+[`solana-portal`](https://github.com/m0-platform/solana-portal); $M extensions (wM and
 others, including the `ext_swap` program) live in
-[`solana-m-extensions`](https://github.com/m0-foundation/solana-m-extensions).
+[`solana-m-extensions`](https://github.com/m0-platform/solana-m-extensions).
 
 ## How yield flows
 

--- a/programs/earn/README.md
+++ b/programs/earn/README.md
@@ -27,7 +27,7 @@ Program ID: `mz2vDzjbQDUDXBH6FPF5s4odCJ4y8YLE5QWaZ8XdZ9Z`
   `m_mint`, `portal_authority`, `ext_swap_global_account`, `earner_merkle_root`, `bump`.
 - The Portal's token authority is derived with seed `"authority"` under the Portal program
   (`MzBrgc8yXBj4P16GTkcSyDZkEQZB9qDqf3fh9bByJce`, source in
-  [solana-portal](https://github.com/m0-foundation/solana-portal)).
+  [solana-portal](https://github.com/m0-platform/solana-portal)).
 
 `initialize` enforces that the $M mint carries the **ScaledUiAmount**, **DefaultAccountState
 (Frozen)**, and **PermanentDelegate** extensions with the `EarnGlobal` PDA as scaled-ui

--- a/services/yield-bot/Dockerfile
+++ b/services/yield-bot/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:22-alpine
 
-LABEL org.opencontainers.image.source=https://github.com/m0-foundation/solana-m
+LABEL org.opencontainers.image.source=https://github.com/m0-platform/solana-m
 LABEL org.opencontainers.image.description="Yield Bot"
 
 WORKDIR /app

--- a/services/yield-bot/README.md
+++ b/services/yield-bot/README.md
@@ -1,7 +1,7 @@
 # yield-bot
 
 Cranks yield distribution for M extension tokens (currently wM and USDKY, programs in
-[solana-m-extensions](https://github.com/m0-foundation/solana-m-extensions)). For each
+[solana-m-extensions](https://github.com/m0-platform/solana-m-extensions)). For each
 extension it builds an index-sync instruction and — for `Crank`-variant extensions — a claim
 instruction per earner, simulates the batch, and sends transactions in batches of 10. Before
 distributing, it verifies the indexed MongoDB data is up to date with the chain and aborts if


### PR DESCRIPTION
This PR updates the GitHub org name from `m0-foundation` to `m0-platform`.
Intentionally, the scope of this PR is kept small so the NPM package has not been touched (yet).
This might be done on a follow-up PR.

