### PR TITLE
fix: yield bot docker contained failed based on missing typescript compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,14 +122,14 @@ define deploy-yield-bot
 	railway environment $(1)
 	docker build --build-arg now="$$(date -u +"%Y-%m-%dT%H:%M:%SZ")" --platform linux/amd64 -t ghcr.io/m0-platform/solana-m:yield-bot -f services/yield-bot/Dockerfile .
 	docker push ghcr.io/m0-platform/solana-m:yield-bot
-	railway redeploy --service "yield bot" --yes
+	railway redeploy --service $(2) --yes
 endef
 
 deploy-yield-bot-devnet:
-	$(call deploy-yield-bot,development)
+	$(call deploy-yield-bot,development,"yield bot")
 
 deploy-yield-bot-mainnet:
-	$(call deploy-yield-bot,production)
+	$(call deploy-yield-bot,production,"yield bot - wM")
 
 #
 # Substreams

--- a/services/yield-bot/Dockerfile
+++ b/services/yield-bot/Dockerfile
@@ -11,7 +11,7 @@ COPY ./services/yield-bot ./services/yield-bot
 COPY ./services/shared ./services/shared
 COPY ./sdk ./sdk
 
-RUN npm install -g pnpm ts-node typescript@5 && pnpm install --prod
+RUN npm install -g pnpm ts-node@10.9.2 typescript@5.8.3 && pnpm install --prod --frozen-lockfile
 RUN pnpm cache delete
 RUN npm cache clean --force
 

--- a/services/yield-bot/Dockerfile
+++ b/services/yield-bot/Dockerfile
@@ -11,7 +11,7 @@ COPY ./services/yield-bot ./services/yield-bot
 COPY ./services/shared ./services/shared
 COPY ./sdk ./sdk
 
-RUN npm install -g pnpm ts-node && pnpm install --prod
+RUN npm install -g pnpm ts-node typescript@5 && pnpm install --prod
 RUN pnpm cache delete
 RUN npm cache clean --force
 


### PR DESCRIPTION
This PR fixes a bug that only occurred in the Docker container of the `yield-bot` which was missing a `typescript` dependency on the `/app` level in the container.
Installing it during the build phase of the Docker image fixes this.

Additionally, a mismatch between the Railway project names for the yield bot (`yield bot` for development, `yield bot - wM` for production) was also addressed here.

### Verification

To verify the fix, build the Docker image locally before this fix and after and run the Docker container.

```
docker image rm ghcr.io/m0-platform/solana-m:yield-bot && \
docker build --build-arg now="$$(date -u +"%Y-%m-%dT%H:%M:%SZ")" --platform linux/amd64 -t ghcr.io/m0-platform/solana-m:yield-bot -f services/yield-bot/Dockerfile . && \
docker run --rm --platform linux/amd64 ghcr.io/m0-platform/solana-m:yield-bot
```

Before applying the fix there is an error with the Typescript setup which doesn't allow the script itself to run:

```
/usr/local/lib/node_modules/ts-node/dist/index.js:157
    const targetSupportsTla = config.options.target >= ts.ScriptTarget.ES2018;
                                                                       ^
TypeError: Cannot read properties of undefined (reading 'ES2018')
    at createFromPreloadedConfig (/usr/local/lib/node_modules/ts-node/dist/index.js:157:72)
    [...]
Node.js v22.23.1
```

After applying the fix and running as-is (not supplying env vars), the resulting error shows that the environment variables are missing, which shows that the script is now starting correctly.

```json
{"imageBuild":"2026-07-22T22:05:31Z","level":"error","message":"A signer or turnkey setup is required","name":"yield-bot", ...}
```

This was deployed to Railway already and functions as expected 👍.
